### PR TITLE
Fix: Collections/state consistencies, concurrently dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This will start the node backend and the web page for testing and development.  
 
 1. Start dev server and web app
     ```
-    npm run start-test-server
-    npm start
+    npm run dev
     ```
 2. Open web browser to http://localhost:3000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poketrax",
-  "version": "0.4.1",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "poketrax",
-      "version": "0.4.1",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
@@ -61,6 +61,7 @@
         "xhr2": "^0.2.1"
       },
       "devDependencies": {
+        "concurrently": "^7.2.2",
         "cypress": "^9.6.1",
         "electron": "^17.4.0",
         "electron-builder": "^23.0.3",
@@ -5962,6 +5963,141 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/concurrently": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.2.2.tgz",
+      "integrity": "sha512-DcQkI0ruil5BA/g7Xy3EWySGrFJovF5RYAYxwGvv9Jf9q9B1v3jPFP2tl6axExNf1qgF30kjoNYrangZ0ey4Aw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.16.1",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.0.0",
+        "shell-quote": "^1.7.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concurrently/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -6756,6 +6892,19 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dayjs": {
@@ -15165,6 +15314,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "dev": true
+    },
     "node_modules/spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -15938,6 +16093,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -21847,6 +22011,106 @@
         }
       }
     },
+    "concurrently": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-7.2.2.tgz",
+      "integrity": "sha512-DcQkI0ruil5BA/g7Xy3EWySGrFJovF5RYAYxwGvv9Jf9q9B1v3jPFP2tl6axExNf1qgF30kjoNYrangZ0ey4Aw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.16.1",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.0.0",
+        "shell-quote": "^1.7.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.5.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
+        }
+      }
+    },
     "config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -22433,6 +22697,12 @@
         "whatwg-mimetype": "^3.0.0",
         "whatwg-url": "^10.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true
     },
     "dayjs": {
       "version": "1.11.2",
@@ -28543,6 +28813,12 @@
         }
       }
     },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
+      "dev": true
+    },
     "spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -29128,6 +29404,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poketrax",
   "productName": "PokeTrax",
-  "version": "0.8.0",
+  "version": "0.7.1",
   "main": "src/server/main.js",
   "homepage": ".",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poketrax",
   "productName": "PokeTrax",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "main": "src/server/main.js",
   "homepage": ".",
   "private": true,
@@ -67,7 +67,8 @@
     "build": "vite build",
     "test": "export NODE_ENV=test && mocha --timeout 60000",
     "test-cypress": "npx cypress run",
-    "make": "vite build && electron-builder"
+    "make": "vite build && electron-builder",
+    "dev": "concurrently --names server,webapp 'npm:start-test-server' 'npm:start'"
   },
   "eslintConfig": {
     "extends": [
@@ -88,6 +89,7 @@
     ]
   },
   "devDependencies": {
+    "concurrently": "^7.2.2",
     "cypress": "^9.6.1",
     "electron": "^17.4.0",
     "electron-builder": "^23.0.3",
@@ -115,7 +117,7 @@
     "win": {
       "artifactName": "poketrax.exe"
     },
-    "snap":{
+    "snap": {
       "artifactName": "poketrax.snap"
     },
     "directories": {

--- a/src/components/AddCardCollection.tsx
+++ b/src/components/AddCardCollection.tsx
@@ -44,7 +44,6 @@ export class AddCardCollection extends React.Component<Props, State> {
         getCollections().then(
             (value) => {
                 this.setState({
-                    ...this.state,
                     collections: value.map((val) => val.name),
                     displayCollections: value.map((val) => val.name)
                 })
@@ -146,7 +145,7 @@ export class AddCardCollection extends React.Component<Props, State> {
                 }
             ).catch(
                 () => {
-                    this.setState({ ...this.state, errorText: "Failed to add :(" })
+                    this.setState({ errorText: "Failed to add :(" })
                 }
             )
         }
@@ -207,7 +206,7 @@ export class AddCardCollection extends React.Component<Props, State> {
                     label="Price Paid (optional)"
                     value={this.state.price}
                     onChange={(ev) => {
-                        this.setState({ ...this.state, price: Number.parseFloat(ev.target.value) })
+                        this.setState({ price: Number.parseFloat(ev.target.value) })
                     }
                     }
                     name="numberformat"
@@ -225,7 +224,7 @@ export class AddCardCollection extends React.Component<Props, State> {
                         error={this.state.gradeErr}
                         value={this.state.grade}
                         onChange={(ev) => {
-                            this.setState({ ...this.state, grade: ev.target.value })
+                            this.setState({ grade: ev.target.value })
                         }}
                         variant="outlined"
                     />
@@ -233,7 +232,7 @@ export class AddCardCollection extends React.Component<Props, State> {
 
                 <div className='h-4'></div>
                 <FormGroup>
-                    <FormControlLabel control={<Switch onChange={(ev) => { this.setState({ ...this.state, wishlist: ev.target.checked }) }} />} label="Wishlist" />
+                    <FormControlLabel control={<Switch onChange={(ev) => { this.setState({ wishlist: ev.target.checked }) }} />} label="Wishlist" />
                 </FormGroup>
                 <div className='h-4'></div>
                 <TextField
@@ -243,7 +242,7 @@ export class AddCardCollection extends React.Component<Props, State> {
                     error={this.state.countErr}
                     value={this.state.count}
                     disabled={this.state.wishlist}
-                    onChange={(ev) => this.setState({ ...this.state, count: Number.parseFloat(ev.target.value) })}
+                    onChange={(ev) => this.setState({ count: Number.parseFloat(ev.target.value) })}
                     name="numberformat"
                     InputProps={{
                         inputComponent: this.CountFormat as any,

--- a/src/components/AddCardCollection.tsx
+++ b/src/components/AddCardCollection.tsx
@@ -38,6 +38,9 @@ export class AddCardCollection extends React.Component<Props, State> {
         this.state = new State()
         this.variants = JSON.parse(props.card.variants ?? '[]')
         this.selectedVariant = this.variants ? this.variants[0] : ""
+    }
+    
+    componentDidMount(): void {
         getCollections().then(
             (value) => {
                 this.setState({

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,75 +1,104 @@
-import React from 'react';
-import '../index.css';
-import Cards from "./CardSearch"
-import { Expansions } from "./Expansions"
-import LinearProgress from '@mui/material/LinearProgress';
-import { Subject, timer } from 'rxjs'
-import { DbState, getDbState, openLink } from '../controls/CardDB';
-import { Collections } from './Collections';
-import { ProductSearch } from './ProductSearch';
-import Snackbar from '@mui/material/Snackbar';
+import React from "react";
+import "../index.css";
+import Cards from "./CardSearch";
+import { Expansions } from "./Expansions";
+import LinearProgress from "@mui/material/LinearProgress";
+import { Subject, timer } from "rxjs";
+import { DbState, getDbState, openLink } from "../controls/CardDB";
+import { Collections } from "./Collections";
+import { ProductSearch } from "./ProductSearch";
+import Snackbar from "@mui/material/Snackbar";
 
-import { Button } from '@mui/material';
+import { Button } from "@mui/material";
 
 class State {
-    page: string = ""
-    selectedSet: string = ""
-    dbState: DbState = new DbState()
+    page: string = "";
+    selectedSet: string = "";
+    dbState: DbState = new DbState();
 }
 
 export interface AppControl {
-    page: string
-    selectedSet: string
+    page: string;
+    selectedSet: string;
 }
 
-export const AppController = new Subject<AppControl>()
+export const AppController = new Subject<AppControl>();
 export class App extends React.Component<{}, State> {
     constructor(props: object) {
-        super(props)
-        this.state = new State()
-        AppController.subscribe(
-            (msg) => {
+        super(props);
+        this.state = new State();
+    }
+
+    componentDidMount(): void {
+        AppController.subscribe({
+            next: (msg) => {
                 if (msg.selectedSet === "") {
-                    this.setState({ ...this.state, selectedSet: "" })
+                    this.setState({ ...this.state, selectedSet: "" });
                 } else {
-                    this.setPage(msg.page, msg.selectedSet)
+                    this.setPage(msg.page, msg.selectedSet);
                 }
-            }
-        )
+            },
+        });
         //checks to see if update is happing
-        let dbcheck = timer(0, 100).subscribe(
-            () => {
-                getDbState().then(
-                    (state) => {
-                        this.setState({ ...this.state, dbState: state })
-                        if (state.ready) {
-                            this.setPage('cards')
-                            dbcheck.unsubscribe()
-                        }
-                    }
-                )
-            }
-        )
+        let dbcheck = timer(0, 100).subscribe(() => {
+            getDbState().then((state) => {
+                this.setState({ ...this.state, dbState: state });
+                if (state.ready) {
+                    this.setPage("cards");
+                    dbcheck.unsubscribe();
+                }
+            });
+        });
     }
 
     private titleBar() {
         return (
             <div className="sticky top-0 w-full h-16 bg-gray-400 flex flex-row">
                 <div className="h-16 flex-none flex flex-row">
-                    <img className="h-16 w-16 p-1" src={"./assests/poketrax.png"} alt="" />
-                    <span className="font-sans text-3xl pt-3 pl-2">PokéTrax</span>
+                    <img
+                        className="h-16 w-16 p-1"
+                        src={"./assests/poketrax.png"}
+                        alt=""
+                    />
+                    <span className="font-sans text-3xl pt-3 pl-2">
+                        PokéTrax
+                    </span>
                     <span className="pl-6 flex ">
-                        <button id="cards-page" className='hover:text-blue-700' onClick={() => this.setPage("cards")}>Cards</button>
+                        <button
+                            id="cards-page"
+                            className="hover:text-blue-700"
+                            onClick={() => this.setPage("cards")}
+                        >
+                            Cards
+                        </button>
                         <div className="w-6"></div>
-                        <button id="sets-page" className='hover:text-blue-700' onClick={() => this.setPage("sets")}>Sets</button>
+                        <button
+                            id="sets-page"
+                            className="hover:text-blue-700"
+                            onClick={() => this.setPage("sets")}
+                        >
+                            Sets
+                        </button>
                         <div className="w-6"></div>
-                        <button id="sealed-page" className='hover:text-blue-700' onClick={() => this.setPage("sealed")}>Sealed Products</button>
+                        <button
+                            id="sealed-page"
+                            className="hover:text-blue-700"
+                            onClick={() => this.setPage("sealed")}
+                        >
+                            Sealed Products
+                        </button>
                         <div className="w-6"></div>
-                        <button id="collection-page" className='hover:text-blue-700' onClick={() => this.setPage("collections")}>Collections</button>
+                        <button
+                            id="collection-page"
+                            className="hover:text-blue-700"
+                            onClick={() => this.setPage("collections")}
+                        >
+                            Collections
+                        </button>
                     </span>
                 </div>
             </div>
-        )
+        );
     }
 
     private setPage(page: string, selectedSet?: string) {
@@ -77,8 +106,8 @@ export class App extends React.Component<{}, State> {
             this.setState({
                 ...this.state,
                 page: page ?? this.state.page,
-                selectedSet: selectedSet ?? this.state.selectedSet
-            })
+                selectedSet: selectedSet ?? this.state.selectedSet,
+            });
         }
     }
 
@@ -87,44 +116,62 @@ export class App extends React.Component<{}, State> {
             <Snackbar
                 anchorOrigin={{ vertical: "top", horizontal: "center" }}
                 open={this.state.dbState.newSoftware}
-                onClose={() => { this.setState({ ...this.state, dbState: { ready: this.state.dbState.ready, updated: this.state.dbState.updated, newSoftware: false } }) }}
+                onClose={() => {
+                    this.setState({
+                        ...this.state,
+                        dbState: {
+                            ready: this.state.dbState.ready,
+                            updated: this.state.dbState.updated,
+                            newSoftware: false,
+                        },
+                    });
+                }}
                 message="New Version Available!! "
-                action={<Button onClick={() => openLink("newSoftware", null)}>Download</Button>}
+                action={
+                    <Button onClick={() => openLink("newSoftware", null)}>
+                        Download
+                    </Button>
+                }
             />
-        )
+        );
     }
 
     private content() {
-        let message
+        let message;
         let content;
         switch (this.state.page) {
-            case 'cards':
-                content = (<Cards selectedSet={this.state.selectedSet}></Cards>)
-                break
-            case 'sets':
-                content = (<Expansions></Expansions>)
-                break
-            case 'collections':
-                content = <Collections></Collections>
-                break
-            case 'sealed':
-                content = <ProductSearch></ProductSearch>
-                break
+            case "cards":
+                content = <Cards selectedSet={this.state.selectedSet}></Cards>;
+                break;
+            case "sets":
+                content = <Expansions></Expansions>;
+                break;
+            case "collections":
+                content = <Collections></Collections>;
+                break;
+            case "sealed":
+                content = <ProductSearch></ProductSearch>;
+                break;
             default:
-                message = (this.state.dbState.updated ? "Downloading New Data" : "Loading Database") + "...";
+                message =
+                    (this.state.dbState.updated
+                        ? "Downloading New Data"
+                        : "Loading Database") + "...";
                 content = (
-                    <div className='absolute justify-items-center items-center w-full'>
+                    <div className="absolute justify-items-center items-center w-full">
                         <LinearProgress id="app-loading-bar"></LinearProgress>
-                        <div className='h-16'></div>
-                        <div className='flex'>
-                            <div className='grow'></div>
-                            <span className='text-2xl' id="loading-message">{message}</span>
-                            <div className='grow'></div>
+                        <div className="h-16"></div>
+                        <div className="flex">
+                            <div className="grow"></div>
+                            <span className="text-2xl" id="loading-message">
+                                {message}
+                            </span>
+                            <div className="grow"></div>
                         </div>
                     </div>
-                )
+                );
         }
-        return content
+        return content;
     }
 
     render() {
@@ -133,10 +180,17 @@ export class App extends React.Component<{}, State> {
                 {this.titleBar()}
                 {this.newVersionPopup()}
                 {this.content()}
-                <div className='text-xs'>The information presented on this application about the Pokémon Trading Card Game, including images and text, is copyright of The Pokémon Company, Nintendo, Game Freak, Creatures and/or Wizards of the Coast. This website is not produced by, endorsed by, supported by, or affiliated with any of these companies.</div>
+                <div className="text-xs">
+                    The information presented on this application about the
+                    Pokémon Trading Card Game, including images and text, is
+                    copyright of The Pokémon Company, Nintendo, Game Freak,
+                    Creatures and/or Wizards of the Coast. This website is not
+                    produced by, endorsed by, supported by, or affiliated with
+                    any of these companies.
+                </div>
             </div>
-        )
+        );
     }
 }
 
-export default App
+export default App;

--- a/src/components/CardCase.tsx
+++ b/src/components/CardCase.tsx
@@ -39,6 +39,7 @@ const rainbowHolo = `linear-gradient(
     rgba(255, 0, 0, 1) 100%`
 interface Props {
     id?: string
+    key?: string
     card: Card
     onDelete: () => void
 }
@@ -307,11 +308,11 @@ export class CardCase extends React.Component<Props, State> {
         </div>)
     }
 
-    componentWillReceiveProps(props: Props) {
-        if (props.card.cardId !== this.props.card.cardId) {
-            this.setState(new State(props.card.count ?? 0))
+   componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any): void {
+        if (prevProps.card.cardId !== this.props.card.cardId) {
+            this.setState(new State(this.props.card.count ?? 0))
         }
-    }
+   }
 
     render() {
         return (

--- a/src/components/CardSearch.tsx
+++ b/src/components/CardSearch.tsx
@@ -49,7 +49,10 @@ export class CardSearch extends React.Component<Props, State> {
         if (props.selectedSet !== '') {
             this.state = new State(props.selectedSet)
         }
-        AppController.next({ page: "", selectedSet: "" })
+    }
+    
+    componentDidMount() {
+        AppController.next({ page: "", selectedSet: "" });
         expansions().then(
             (data) => {
                 this.setState({ ...this.state, sets: data.map((exp) => exp.name) })
@@ -59,7 +62,7 @@ export class CardSearch extends React.Component<Props, State> {
             console.log(value)
             this.setState({ ...this.state, rarities: value })
         })
-        this.setSearch(0)
+        this.setSearch(0);
     }
 
     private handleChangePage = (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number,) => {
@@ -252,12 +255,14 @@ export class CardSearch extends React.Component<Props, State> {
     }
 
     renderCards() {
-        let items = []
-        for (let i = 0; i < this.state.cards.length; i++) {
-            let card = this.state.cards[i]
-            items.push(<CardCase id={`${i}`} card={card} onDelete={() => { }} ></CardCase>)
-        }
-        return items
+        return this.state.cards.map((card, i) => (
+            <CardCase
+                id={`${i}`}
+                key={card.cardId}
+                card={card}
+                onDelete={() => {}}
+            ></CardCase>
+        ));
     }
 }
 

--- a/src/components/CollectionButtons.tsx
+++ b/src/components/CollectionButtons.tsx
@@ -34,6 +34,9 @@ export class CollectionButtons extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
         this.state = new State()
+    }
+    
+    componentDidMount(): void {
         getCollections().then(
             (value) => {
                 this.setState({ ...this.state, collections: value })

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -95,7 +95,7 @@ function AddDialog(props: DialogProps) {
             addCollection(name).then(
                 (_) => {
                     setInProg(false)
-                    setName("")
+                    // setName("")
                     onConfirm(name)
                     onClose()
                 }
@@ -312,31 +312,28 @@ export class Collections extends React.Component<{}, State> {
     constructor(props: {}) {
         super(props)
         this.state = new State()
-        rarities().then(
-            (value) => {
-                this.setState({ ...this.state, rarities: value })
-            }
-        )
-        getCollections().then(
-            (value) => {
-                let selected = ""
-                if (value.length !== 0 && this.state.collection === "") {
-                    selected = value[0].name
-                } else {
-                    selected = this.state.collection
+    }
+    
+    componentDidMount(): void {
+        Promise.all([rarities(), getCollections()])
+            .then(
+                ([rarities, collections]) => {
+                    this.setState({rarities, collections}, () => {
+                        const selected = collections.length > 0 && this.state.collection === "" ?
+                            collections[0].name : this.state.collection;
+                        this.setCollection(selected, this.state.page)
+                    })
                 }
-                this.setState({ ...this.state, collections: value })
-                this.setCollection(selected, this.state.page)
-            }
-        )
+            );
     }
 
     public searchTerm = ""
 
     private _getCollections() {
         getCollections().then(
-            (value) => {
-                this.setState({ ...this.state, collections: value })
+            (collections) => {
+                console.log(this.state);
+                this.setState({ collections })
             }
         )
     }
@@ -353,7 +350,7 @@ export class Collections extends React.Component<{}, State> {
             }
             this.setState({
                 ...this.state,
-                collection: collection,
+                collection,
                 collections: this.state.collections.filter((value) => value.name !== _collection)
             })
         }
@@ -361,7 +358,7 @@ export class Collections extends React.Component<{}, State> {
             getCollectionValue(_collection)
                 .then(
                     (value) => {
-                        this.setState({ ...this.state, totalValue: value.data.totalValue })
+                        this.setState({ totalValue: value.data.totalValue })
                     }
                 )
             let _display = display ?? this.state.display
@@ -371,15 +368,14 @@ export class Collections extends React.Component<{}, State> {
                         (search) => {
                             this.setState(
                                 {
-                                    ...this.state,
                                     total: search.total,
                                     collectionCards: search.cards,
-                                    collection: collection,
+                                    collection,
                                     searchValue: searchValue ?? this.state.searchValue,
                                     rareSelected: rarityFilter ?? this.state.rareSelected,
                                     sort: sort ?? this.state.sort,
                                     display: display ?? this.state.display,
-                                    page: page
+                                    page
                                 }
                             )
                         }
@@ -390,15 +386,14 @@ export class Collections extends React.Component<{}, State> {
                         (search) => {
                             this.setState(
                                 {
-                                    ...this.state,
                                     total: search.total,
                                     collectionProducts: search.products,
-                                    collection: collection,
+                                    collection,
                                     searchValue: searchValue ?? this.state.searchValue,
                                     rareSelected: rarityFilter ?? this.state.rareSelected,
                                     sort: sort ?? this.state.sort,
                                     display: display ?? this.state.display,
-                                    page: page
+                                    page
                                 }
                             )
                         }
@@ -408,15 +403,18 @@ export class Collections extends React.Component<{}, State> {
     }
 
     private generateTabs(): JSX.Element[] {
-        let tabs = []
-        for (let coll of this.state.collections) {
-            tabs.push((<Tab id={`tab-${coll.name.replace(" ", "-")}`} label={coll.name} value={coll.name} />))
-        }
-        return tabs;
+        return this.state.collections.map((coll, i) => (
+            <Tab
+                key={i}
+                id={`tab-${coll.name.replace(" ", "-")}`}
+                label={coll.name}
+                value={coll.name}
+            />
+        ));
     }
 
     private closeDialog() {
-        this.setState({ ...this.state, addDialogOpen: false, deleteDialogOpen: false, renameDialogOpen: false })
+        this.setState({addDialogOpen: false, deleteDialogOpen: false, renameDialogOpen: false })
         this._getCollections()
     }
 
@@ -425,19 +423,16 @@ export class Collections extends React.Component<{}, State> {
     };
 
     private renderCards() {
-        let items = []
-        for (let i = 0; i < this.state.collectionCards.length; i++) {
-            let card = this.state.collectionCards[i]
-            items.push(
-                <CardCase
-                    id={`card-case-${i}`}
-                    card={card}
-                    onDelete={() => {
-                        this.setCollection(this.state.collection, this.state.page)
-                    }}>
-                </CardCase>)
-        }
-        return items
+        return this.state.collectionCards.map((card, i) => (
+            <CardCase
+                key={`${i}`}
+                id={`card-case-${i}`}
+                card={card}
+                onDelete={() => {
+                    this.setCollection(this.state.collection, this.state.page);
+                }}
+            ></CardCase>
+        ));
     }
 
     private renderProducts() {
@@ -505,7 +500,7 @@ export class Collections extends React.Component<{}, State> {
         }
     }
 
-    private raritiyFilter() {
+    private rarityFilter() {
         return (
             <Autocomplete
                 className='pl-4 min-w-min w-72'
@@ -626,31 +621,37 @@ export class Collections extends React.Component<{}, State> {
                         size='small'
                         id="add-collection-button"
                         color="primary"
-                        onClick={() => { this.setState({ ...this.state, addDialogOpen: true }) }}>
+                        onClick={() => { this.setState({ addDialogOpen: true }) }}>
                         <AddIcon></AddIcon>
                     </Fab>
                 </Tooltip>
                 <div className='w-4'></div>
                 <Tooltip title="Rename Collection">
-                    <Fab
-                        size='small'
-                        id="rename-collection-button"
-                        color="primary"
-                        onClick={() => { this.setState({ ...this.state, renameDialogOpen: true }) }}>
-                        <EditIcon />
-                    </Fab>
+                    <span>
+                        <Fab
+                            disabled={this.state.collections.length === 0}
+                            size='small'
+                            id="rename-collection-button"
+                            color="primary"
+                            onClick={() => { this.setState({ renameDialogOpen: true }) }}>
+                            <EditIcon />
+                        </Fab>
+                    </span>
                 </Tooltip>
                 <div className='w-4'></div>
                 <DownloadMenu name={this.state.collection}></DownloadMenu>
                 <div className='w-4'></div>
                 <Tooltip title="Delete Collection">
-                    <Fab
-                        id="delete-collection-button"
-                        size="small"
-                        color="error"
-                        onClick={() => { this.setState({ ...this.state, deleteDialogOpen: true }) }}>
-                        <DeleteForeverIcon />
-                    </Fab>
+                    <span>
+                        <Fab
+                            disabled={this.state.collections.length === 0}
+                            id="delete-collection-button"
+                            size="small"
+                            color="error"
+                            onClick={() => { this.setState({ deleteDialogOpen: true }) }}>
+                            <DeleteForeverIcon />
+                        </Fab>
+                    </span>
                 </Tooltip>
             </div>
         )
@@ -671,7 +672,7 @@ export class Collections extends React.Component<{}, State> {
                                     this.setCollection(this.state.collection, 0, false, this.searchTerm)
                                 }
                             }} />
-                        {this.raritiyFilter()}
+                        {this.rarityFilter()}
                         <div className='flex-grow'></div>
                         {this.collectionDisplayToggle()}
                         <div className='w-4'></div>
@@ -686,13 +687,18 @@ export class Collections extends React.Component<{}, State> {
         return (
             <div>
                 <div className="flex h-16 w-full justify-center items-center pr-4 bg-gray-200">
-                    <Tabs
-                        id="collection-tabs"
-                        className="flex-grow"
-                        value={this.state.collection}
-                        onChange={this.setCollectionEvent} variant="scrollable" scrollButtons="auto">
-                        {this.generateTabs()}
-                    </Tabs>
+                    {this.state.collections.length > 0 && (
+                            <Tabs
+                                id="collection-tabs"
+                                className="flex-grow"
+                                value={this.state.collection !== "" ? this.state.collection : false}
+                                onChange={this.setCollectionEvent}
+                                variant="scrollable"
+                                scrollButtons="auto"
+                            >
+                                {this.generateTabs()}
+                            </Tabs>
+                        )}
                     {this.fabButtons()}
                 </div>
                 <div>

--- a/src/components/DownloadMenu.tsx
+++ b/src/components/DownloadMenu.tsx
@@ -35,14 +35,17 @@ export default class DownloadMenu extends React.Component<Collection, State>  {
         return (
             <div>
                 <Tooltip title="Download Collection">
-                    <Fab
-                        id="download-menu-open"
-                        aria-haspopup="true"
-                        size="small"
-                        color="primary"
-                        onClick={(ev) => this.handleClick(ev)}>
-                        <DownloadIcon />
-                    </Fab>
+                    <span>
+                        <Fab
+                            disabled={this.props.name === ""}
+                            id="download-menu-open"
+                            aria-haspopup="true"
+                            size="small"
+                            color="primary"
+                            onClick={(ev) => this.handleClick(ev)}>
+                            <DownloadIcon />
+                        </Fab>
+                    </span>
                 </Tooltip>
                 <Menu
                     id="download-menu"

--- a/src/controls/CardDB.tsx
+++ b/src/controls/CardDB.tsx
@@ -164,43 +164,19 @@ export async function getCollectionSealed(collection: string, page: number, sear
 /**
  * Add new collection. name must be unique
  * @param name 
- * @returns 
+ * @returns empty string
  */
 export function addCollection(name: string): Promise<any> {
-    return new Promise<any>(
-        (resolve, reject) => {
-            axios.put(`${baseURL}/collections`, { name: name }).then(
-                (_) => {
-                    resolve("")
-                }
-            ).catch(
-                (err) => {
-                    reject(err)
-                }
-            )
-        }
-    )
+    return axios.put(`${baseURL}/collections`, { name: name }).then(() => "");
 }
 
 /**
- * Delete dentire collection
+ * Delete entire collection
  * @param name 
- * @returns 
+ * @returns empty string
  */
 export function deleteCollection(name: string): Promise<any> {
-    return new Promise<any>(
-        (resolve, reject) => {
-            axios.delete(`${baseURL}/collections`, { data: { name: name } }).then(
-                (_) => {
-                    resolve("")
-                }
-            ).catch(
-                (err) => {
-                    reject(err)
-                }
-            )
-        }
-    )
+    return axios.delete(`${baseURL}/collections`, { data: { name: name } }).then(() => "");
 }
 
 /**

--- a/src/server/database.js
+++ b/src/server/database.js
@@ -67,7 +67,6 @@ const checkForDbUpdate = () => {
     return new Promise(
         async (resolve, reject) => {
             //search for folder
-
             if (fs.existsSync(path.join(pwd(), "./sql")) === false) {
                 fs.mkdirSync(path.join(pwd(), "./sql"), { recursive: true })
             }
@@ -198,7 +197,7 @@ function getTcgpPrice(card) {
     let db = pricesDB()
     return new Promise(
         (resolve, reject) => {
-            axios.get(`https://infinite-api.tcgplayer.com/price/history/${card.idTCGP}?range=month`).then(
+            axios.get(`https://infinite-api.tcgplayer.com/price/history/${card.idTCGP}?range=quarter`, {decompress: true}).then(
                 (res) => {
                     let prices = []
                     if (res.data.count === 0) {
@@ -232,7 +231,8 @@ function getTcgpPrice(card) {
                     resolve(prices)
                 }
             ).catch((err) => {
-                reject(err)
+                console.log(err.message)
+                reject()
             }
             )
         }
@@ -440,7 +440,7 @@ const init = async () => {
         let prices = pricesDB()
         prices.prepare(`CREATE TABLE IF NOT EXISTS prices (id TEXT UNIQUE, date TEXT, cardId TEXT, variant TEXT, vendor TEXT, price REAL)`).run()
         prices.prepare(`CREATE TABLE IF NOT EXISTS productPrices (id TEXT UNIQUE, date TEXT, name TEXT, vendor TEXT, price REAL)`).run()
-        upgradePrices(prices)
+        //upgradePrices(prices)
         prices.close()
         let collections = collectionDB()
         collections.prepare(`CREATE TABLE IF NOT EXISTS collections (name TEXT UNIQUE, img TEXT)`).run()


### PR DESCRIPTION
I went through and did a once through for some of the react components. Most of the issues pertained to:

1. Removed the `...this.state` part of `this.setState({...this.state, <some changes>})` in a bunch of places. The function does a shallow merge of this.state anyway, and I think it may actually confuse change detection.
2. Moved after-construction init code to onComponentMount in some places to make sure state was actually available at the point at which the function fired off.
3. See the comments/changes around L348 of Collections.tsx... In order to get Tabs to not throw a fit when we were adding/removing collections, I had to do some reacty state-juggling things.
4. Added the `key=<some-key>` prop for any components that we loop over as required by React.
    - I still need to go through a bunch of the other components and do this so my console doesn't light on fire when I navigate through the application.
6. Added the dev dependency **concurrently**. With this thing, we can now stand up both the test webserver and the react app all with one command and run them together. Added `npm start dev` and updated the README.