### PR TITLE
tidy: database.js promise cleanup.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poketrax",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "poketrax",
-      "version": "0.8.0",
+      "version": "0.7.2",
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
@@ -62,6 +62,7 @@
         "xhr2": "^0.2.1"
       },
       "devDependencies": {
+        "@types/node-fetch": "^2.6.2",
         "concurrently": "^7.2.2",
         "cypress": "^10.3.0",
         "electron": "^19.0.7",
@@ -3565,6 +3566,30 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
       "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -4937,9 +4962,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.5.3.tgz",
-      "integrity": "sha512-tNIrDsThpWT8j1mg+svI1pqCYROqNOWMbB2qXVg+TJqH9UR5XnbAHyRsLZoJagldGTTqJPj/sUPVOkW0GRpYqw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.0.tgz",
+      "integrity": "sha512-wYckL8S8RHP+KKNsZuJGZ7z/6FFmVgwd0U8jSv6t997C+EFR1yvi8p2WIpTb10jiV5rRA5VtMdgtAZFcAnK3Iw==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -7813,6 +7838,16 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -20147,6 +20182,29 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
       "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ=="
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -21213,9 +21271,9 @@
       }
     },
     "better-sqlite3": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.5.3.tgz",
-      "integrity": "sha512-tNIrDsThpWT8j1mg+svI1pqCYROqNOWMbB2qXVg+TJqH9UR5XnbAHyRsLZoJagldGTTqJPj/sUPVOkW0GRpYqw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.0.tgz",
+      "integrity": "sha512-wYckL8S8RHP+KKNsZuJGZ7z/6FFmVgwd0U8jSv6t997C+EFR1yvi8p2WIpTb10jiV5rRA5VtMdgtAZFcAnK3Iw==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"
@@ -23389,6 +23447,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     ]
   },
   "devDependencies": {
+    "@types/node-fetch": "^2.6.2",
     "concurrently": "^7.2.2",
     "cypress": "^10.3.0",
     "electron": "^19.0.7",
@@ -110,6 +111,7 @@
   },
   "build": {
     "appId": "github.com/jgunzelman88/PokeTrax",
+    "buildDependenciesFromSource": true,
     "extraFiles": {
       "from": "./dist",
       "to": "./"

--- a/src/controls/CardDB.tsx
+++ b/src/controls/CardDB.tsx
@@ -14,6 +14,7 @@ export class DbState {
     public ready: boolean = false
     public updated: boolean = false
     public newSoftware: boolean = false
+    public error?: any;
 }
 
 export function search(page: number, term?: string, sets?: string[], rarity?: string[], sort?: string): Promise<CardSearch> {

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -43,7 +43,7 @@ export class App extends React.Component<{}, State> {
         let dbcheck = timer(0, 100).subscribe(() => {
             getDbState().then((state) => {
                 this.setState({ ...this.state, dbState: state });
-                if (state.ready) {
+                if (state.ready || state.error != null) {
                     this.setPage("cards");
                     dbcheck.unsubscribe();
                 }

--- a/src/server/database.js
+++ b/src/server/database.js
@@ -1,473 +1,497 @@
-const path = require('path')
-const { app } = require('electron');
-const os = require("os");
-const fs = require('fs');
-const compver = require('compare-version');
-const https = require("follow-redirects").https
-const axios = require('axios')
-const hash = require('object-hash');
-const { parse } = require('json2csv');
-const DB_META = "./sql/meta.json"
-const CARD_DB_FILE = "./sql/data.sqlite3"
-const PRICE_DB_FILE = "./sql/prices.sqlite3"
-const COLLECTION_DB_FILE = "./sql/collections.sqlite3"
-const Database = require('better-sqlite3');
-const fetch = require('node-fetch');
+const { app } = require("electron");
+const compver = require("compare-version");
+const Database = require("better-sqlite3");
+const fetch = require("node-fetch");
+const fs = require("fs");
+const hash = require("object-hash");
+const https = require("follow-redirects").https;
+const { parse } = require("json2csv");
+const path = require("path");
 
-/* Print the working directory for the application to get date files */
-const pwd = () => {
-    if (process.env.NODE_ENV === 'development') {
-        return "./dev-data"
-    } else if (process.env.NODE_ENV === 'ci-test') {
-        return path.join(process.env.PWD, "/build")
-    } else if (process.env.NODE_ENV === 'test') {
-        return "./test/data"
-    }
-    return app.getPath("appData")
-}
+const { pwd } = require("./utils");
 
-const appPath = () => {
-    if (process.env.NODE_ENV === 'development') {
-        return "./"
-    } else if (process.env.NODE_ENV === 'ci-test') {
-        return path.join(process.env.PWD, "/build")
-    } else if (process.env.NODE_ENV === 'test') {
-        return "./test/data"
-    }
-    switch (os.platform()) {
-        case 'darwin': return '/Applications/PokeTrax.app/Contents/'
-        case 'win32': return ''
-        default: return process.env.PWD
-    }
-}
+const DB_META = "./sql/meta.json";
+const CARD_DB_FILE = "./sql/data.sqlite3";
+const PRICE_DB_FILE = "./sql/prices.sqlite3";
+const COLLECTION_DB_FILE = "./sql/collections.sqlite3";
 
 /**
  * Prices database close when done
  * @returns {Database}
  */
-const pricesDB = () => { return new Database(path.join(pwd(), PRICE_DB_FILE)) }
+const pricesDB = () => {
+    return new Database(path.join(pwd(), PRICE_DB_FILE));
+};
 /**
  * Card database close when done
  * @returns {Database}
  */
-const cardDB = () => { return new Database(path.join(pwd(), CARD_DB_FILE)) }
+const cardDB = () => {
+    return new Database(path.join(pwd(), CARD_DB_FILE));
+};
 /**
  * Collection database close when done
  * @returns {Database}
  */
-const collectionDB = () => { return new Database(path.join(pwd(), COLLECTION_DB_FILE)) }
+const collectionDB = () => {
+    return new Database(path.join(pwd(), COLLECTION_DB_FILE));
+};
+
+/**
+ * @type {{ready: boolean, updated: boolean, error?: any, newSoftware?: boolean}}
+ */
+let dbUpdate = { ready: false, updated: false };
 
 //Check for card Updates
-let dbUpdate = { ready: false, updated: false }
 const dbStatus = () => {
-    return dbUpdate
-}
+    return dbUpdate;
+};
 
-const checkForDbUpdate = () => {
-    // updateCollections()
-    return new Promise(
-        async (resolve, reject) => {
-            //search for folder
-            if (fs.existsSync(path.join(pwd(), "./sql")) === false) {
-                fs.mkdirSync(path.join(pwd(), "./sql"), { recursive: true })
+const checkForDbUpdate = async () => {
+    try {
+        //search for folder
+        if (fs.existsSync(path.join(pwd(), "./sql")) === false) {
+            fs.mkdirSync(path.join(pwd(), "./sql"), { recursive: true });
+        }
+        console.log(`database: ${path.join(pwd(), "./sql")}`);
+        //Init databases
+        const meta = await pullDbMeta();
+        const newSoftware = await checkForSoftwareUpdate();
+        //if new and no meta file exists
+        if (fs.existsSync(path.join(pwd(), DB_META)) === false) {
+            dbUpdate = {
+                ready: false,
+                updated: true,
+                newSoftware,
+            };
+            try {
+                await pullDb(meta);
+            } catch (err) {
+                dbUpdate = {
+                    ready: false,
+                    updated: false,
+                    error: err,
+                    newSoftware,
+                };
             }
-            console.log(`database: ${path.join(pwd(), "./sql")}`)
-            //Init databases
-            let meta = await pullDbMeta()
-            let softwareUpdate = await checkForSoftwareUpdate()
-            //if new and no meta file exists
-            if (fs.existsSync(path.join(pwd(), DB_META)) === false) {
-                dbUpdate = { ready: false, updated: true, newSoftware: softwareUpdate }
+        } else {
+            // look for update
+            await updateCollections();
+            const current = JSON.parse(
+                fs.readFileSync(path.join(pwd(), DB_META), {
+                    encoding: "utf8",
+                    flag: "r",
+                })
+            );
+            if (compver(meta.version, current.version) > 0) {
+                dbUpdate = {
+                    ready: false,
+                    updated: true,
+                    newSoftware,
+                };
                 try {
-                    await pullDb(meta)
-                    resolve()
+                    await pullDb(meta);
                 } catch (err) {
-                    dbUpdate = { ready: false, updated: false, error: err, newSoftware: softwareUpdate }
-                    console.log(err)
-                    reject("can't pull data base")
+                    dbUpdate = {
+                        ready: false,
+                        updated: false,
+                        error: err,
+                        newSoftware,
+                    };
                 }
-            } else { // look for update
-                updateCollections()
-                let current = JSON.parse(fs.readFileSync(path.join(pwd(), DB_META), { encoding: 'utf8', flag: 'r' }))
-                if (compver(meta.version, current.version) > 0) {
-                    dbUpdate = { ready: false, updated: true, newSoftware: softwareUpdate }
-                    try {
-                        await pullDb(meta)
-                        resolve()
-                    } catch (err) {
-                        dbUpdate = { ready: false, updated: false, error: err, newSoftware: softwareUpdate }
-                        console.log(err)
-                        reject("cant pull database")
-                    }
-                } else {
-                    dbUpdate = { ready: true, updated: false, newSoftware: softwareUpdate }
-                    resolve()
-                }
+            } else {
+                dbUpdate = {
+                    ready: true,
+                    updated: false,
+                    newSoftware,
+                };
             }
         }
-    )
-}
+    } catch (err) {
+        dbUpdate = {
+            ready: false,
+            updated: false,
+            error: err,
+        };
+    }
+};
 
 async function checkForSoftwareUpdate() {
-    return new Promise(
-        async (resolve, _) => {
-            try {
-                let currentVerion = process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development' ? '1.0.0' : app.getVersion()
-                let release = await axios.get('https://api.github.com/repos/poketrax/poketrax/releases/latest')
-                let latestVersion = release.data.name.replace("v", "").replace("-beta", "")
-                resolve(compver(currentVerion, latestVersion) < 0 ? true : false)
-            } catch (err) {
-                console.log(err)
-                resolve(false)
-            }
-        }
-    )
+    try {
+        const currentVerion =
+            process.env.NODE_ENV === "test" ||
+            process.env.NODE_ENV === "development"
+                ? "1.0.0"
+                : app.getVersion();
+        const release = await fetch(
+            "https://api.github.com/repos/poketrax/poketrax/releases/latest"
+        ).then((res) => res.json());
+        const latestVersion = release.name
+            .replace("v", "")
+            .replace("-beta", "");
+        return compver(currentVerion, latestVersion) < 0 ? true : false;
+    } catch (err) {
+        console.log(err);
+        return false;
+    }
 }
 
 async function updateCollections() {
-    let cdb = collectionDB()
-    let collections = cdb.prepare(`SELECT name from collections`).all() ?? []
-    for (let colleciton of collections) {
-        let cards = cdb.prepare(`SELECT cardId FROM collectionCards WHERE collection = $collection`).all({ collection: colleciton.name }) ?? []
-        for (let cardC of cards) {
-            let carddb = cardDB()
-            let card = carddb.prepare(`SELECT * FROM cards WHERE cardId = $cardId`).get({ cardId: cardC.cardId })
-            await getTcgpPrice(card)
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            carddb.close()
-        }
+    let cdb = collectionDB();
+    // @TODO: We should be able to consolidate this to one SQL query...
+    let collections = cdb.prepare(`SELECT name from collections`).all() ?? [];
+    if (collections.length === 0) {
+        return collections;
     }
+    const updates = [];
+    let carddb = cardDB();
+    try {
+        for (let collection of collections) {
+            let cards =
+                cdb
+                    .prepare(
+                        `SELECT cardId FROM collectionCards WHERE collection = $collection`
+                    )
+                    .all({ collection: collection.name }) ?? [];
+            for (let cardC of cards) {
+                let card = carddb
+                    .prepare(`SELECT * FROM cards WHERE cardId = $cardId`)
+                    .get({ cardId: cardC.cardId });
+                updates.push(getTcgpPrice(card));
+            }
+        }
+        await Promise.all(updates);
+    } catch (err) {
+        console.error(`Error updating card prices: `, err);
+    }
+    [cdb, carddb].forEach((db) => db.close());
 }
 
 //pull release info from database repo
 async function pullDbMeta() {
-    return new Promise(
-        async (resolve, reject) => {
-            try {
-                let release = await axios.get('https://api.github.com/repos/poketrax/pokepull/releases/latest')
-                let asset = release.data.assets.find((value) => value.name === "data.sqlite3")
-                let meta = { 'version': release.data.name, 'asset': asset.browser_download_url }
-                resolve(meta)
-            } catch (err) {
-                reject(err)
-            }
-        }
-    )
+    let release = await fetch(
+        "https://api.github.com/repos/poketrax/pokepull/releases/latest"
+    ).then((res) => res.json());
+    const asset = release.assets.find((value) => value.name === "data.sqlite3");
+    return {
+        version: release.name,
+        asset: asset.browser_download_url,
+    };
 }
 
 //Pull new database file and reinitialize database
 async function pullDb(meta) {
-    return new Promise(
-        async (resolve, reject) => {
-            https.get(meta.asset, (stream) => {
-                //write database file
-                let writer = fs.createWriteStream(path.join(pwd(), CARD_DB_FILE))
-                stream.pipe(writer)
-                writer.on('finish', () => {
-                    fs.writeFileSync(path.join(pwd(), "./sql/meta.json"), JSON.stringify(meta))
-                    dbUpdate = { ready: true, updated: true }
-                    resolve()
-                })
-                writer.on('error', () => { console.log("ERROR"); reject() })
-            })
-        }
-    )
+    return new Promise(async (resolve, reject) => {
+        https.get(meta.asset, (stream) => {
+            //write database file
+            let writer = fs.createWriteStream(path.join(pwd(), CARD_DB_FILE));
+            stream.pipe(writer);
+            writer.on("finish", () => {
+                fs.writeFileSync(
+                    path.join(pwd(), "./sql/meta.json"),
+                    JSON.stringify(meta)
+                );
+                dbUpdate = { ready: true, updated: true };
+                resolve();
+            });
+            writer.on("error", () => {
+                console.log("ERROR");
+                reject();
+            });
+        });
+    });
 }
-
 
 function addPrice(db, price) {
     let sql = `INSERT OR IGNORE INTO prices  
                     (id, date, cardId, variant, vendor, price) 
-                    VALUES ($id, $date, $cardId, $variant, $vendor, $price)`
+                    VALUES ($id, $date, $cardId, $variant, $vendor, $price)`;
     db.prepare(sql).run({
-        "id": hash(price.date + price.cardId + price.variant + "tcgp"),
-        "date": price.date,
-        "cardId": price.cardId,
-        "variant": price.variant,
-        "vendor": price.vendor,
-        "price": price.price
-    })
+        id: hash(price.date + price.cardId + price.variant + "tcgp"),
+        date: price.date,
+        cardId: price.cardId,
+        variant: price.variant,
+        vendor: price.vendor,
+        price: price.price,
+    });
 }
 
 /**
- * Return TCGPrice 
- * @param {Card} card 
- * @returns 
+ * Return TCGPrice
+ * @param {Card} card
+ * @returns An array of TCGPlayer prices.
  */
-function getTcgpPrice(card) {
-    let db = pricesDB()
-    return new Promise(
-        (resolve, reject) => {
-            fetch(`https://infinite-api.tcgplayer.com/price/history/${card.idTCGP}?range=quarter`, {decompress: true})
-            .then(res => res.json())
-            .then(
-                (data) => {
-                    let prices = []
-                    if (data.count === 0) {
-                        for (let variant of JSON.parse(card.variants)) {
-                            let price = {
-                                "date": new Date(Date.now()).toISOString(),
-                                "cardId": card.cardId,
-                                "variant": variant,
-                                "vendor": "tcgp",
-                                "price": 0.0
-                            }
-                            prices.push(price)
-                            addPrice(db, price)
-                        }
-                        resolve(prices)
-                    }
-                    for (let result of data.result) {
-                        let date = new Date(Date.parse(result.date))
-                        for (let variant of result.variants) {
-                            let price = {
-                                "date": date.toISOString(),
-                                "cardId": card.cardId,
-                                "variant": variant.variant,
-                                "vendor": "tcgp",
-                                "price": parseFloat(variant.marketPrice)
-                            }
-                            prices.push(price)
-                            addPrice(db, price)
-                        }
-                    }
-                    resolve(prices)
-                }
-            ).catch((err) => {
-                console.log(err.message)
-                reject()
-            }
-            )
+async function getTcgpPrice(card) {
+    const db = pricesDB();
+    const data = await fetch(
+        `https://infinite-api.tcgplayer.com/price/history/${card.idTCGP}?range=quarter`
+    ).then((res) => res.json());
+    const prices = [];
+    if (data.count === 0) {
+        for (let variant of JSON.parse(card.variants)) {
+            let price = {
+                date: new Date(Date.now()).toISOString(),
+                cardId: card.cardId,
+                variant: variant,
+                vendor: "tcgp",
+                price: 0.0,
+            };
+            prices.push(price);
+            addPrice(db, price);
         }
-    )
+        return prices;
+    }
+    for (let result of data.result) {
+        // @TODO: luxon
+        let date = new Date(Date.parse(result.date));
+        for (let variant of result.variants) {
+            let price = {
+                date: date.toISOString(),
+                cardId: card.cardId,
+                variant: variant.variant,
+                vendor: "tcgp",
+                price: parseFloat(variant.marketPrice),
+            };
+            prices.push(price);
+            addPrice(db, price);
+        }
+    }
+    return prices;
 }
 
 function addPriceProduct(db, price) {
     let sql = `INSERT OR IGNORE INTO productPrices  
                     (id, date, name, vendor, price) 
-                    VALUES ($id, $date, $name, $vendor, $price)`
+                    VALUES ($id, $date, $name, $vendor, $price)`;
     db.prepare(sql).run({
-        "id": hash(price.date + price.name + price.vendor),
-        "date": price.date,
-        "name": price.name,
-        "vendor": price.vendor,
-        "price": price.price
-    })
+        id: hash(price.date + price.name + price.vendor),
+        date: price.date,
+        name: price.name,
+        vendor: price.vendor,
+        price: price.price,
+    });
 }
 
 /**
- * Return TCGPrice 
- * @param {Card} product 
- * @returns 
+ * Return TCGPrice
+ * @param {Card} product
+ * @returns Product prices.
  */
-function getTcgpPriceProduct(product) {
-    let db = pricesDB()
-    return new Promise(
-        (resolve, reject) => {
-            fetch(`https://infinite-api.tcgplayer.com/price/history/${product.idTCGP}?range=month`)
-            .then(res => res.json())
-            .then(
-                (data) => {
-                    let prices = []
-                    if (data.count === 0) {
-                        let price = {
-                            "date": new Date(Date.now()).toISOString(),
-                            "name": product.name,
-                            "vendor": "tcgp",
-                            "price": 0.0
-                        }
-                        prices.push(price)
-                        addPriceProduct(db, price)
-                        resolve(prices)
-                    }
-                    for (let result of data.result) {
-                        let date = new Date(Date.parse(result.date))
-                        for (let variant of result.variants) {
-                            let price = {
-                                "date": date.toISOString(),
-                                "name": product.name,
-                                "vendor": "tcgp",
-                                "price": parseFloat(variant.marketPrice)
-                            }
-                            prices.push(price)
-                            addPriceProduct(db, price)
-                        }
-                    }
-                    resolve(prices)
-                }
-            ).catch((err) => {
-                reject(err)
-            }
-            )
+async function getTcgpPriceProduct(product) {
+    const db = pricesDB();
+    const data = await fetch(
+        `https://infinite-api.tcgplayer.com/price/history/${product.idTCGP}?range=month`
+    ).then((res) => res.json());
+    let prices = [];
+    if (data.count === 0) {
+        let price = {
+            date: new Date(Date.now()).toISOString(),
+            name: product.name,
+            vendor: "tcgp",
+            price: 0.0,
+        };
+        prices.push(price);
+        addPriceProduct(db, price);
+        return prices;
+    }
+    for (let result of data.result) {
+        let date = new Date(Date.parse(result.date));
+        for (let variant of result.variants) {
+            let price = {
+                date: date.toISOString(),
+                name: product.name,
+                vendor: "tcgp",
+                price: parseFloat(variant.marketPrice),
+            };
+            prices.push(price);
+            addPriceProduct(db, price);
         }
-    )
+    }
+    return prices;
 }
 
 /**
  * Get prices from database
  * @param {Card} card
- * @param {number} _start 
- * @param {number} _end 
- * @returns 
+ * @param {number} _start
+ * @param {number} _end
+ * @returns
  */
-const getPrices = (card, _start, _end) => {
-    return new Promise(
-        (resolve, reject) => {
-            let yesterday = new Date(Date.now())
-            yesterday.setDate(yesterday.getDate() - 2)
-            let timeFilter = ``
-            let limit = ``
-            if (_start != null && _end != null) {
-                timeFilter = `AND dateTime(date) > dateTime($start) AND dateTime(date) < dateTime($end)`
-            } else {
-                limit = "LIMIT 1"
-            }
-            let sql = `SELECT date(date) as date, cardId, variant, vendor, price FROM prices WHERE cardId = $cardId ${timeFilter} ORDER BY dateTime(date) DESC ${limit}`
-            let db = pricesDB()
-            try {
-                let rows = db.prepare(sql).all({ "cardId": card.cardId, "start": _start, "end": _end })
-                if (rows.length === 0 || rows[0].date < yesterday.getTime()) {
-                    getTcgpPrice(card).then(
-                        (value) => {
-                            resolve(value)
-                        }
-                    ).catch(
-                        (err) => {
-                            reject(err)
-                        }
-                    )
-                } else {
-                    resolve(rows)
-                }
-            } catch (err) {
-                reject(err)
-            } finally {
-                db.close()
-            }
+const getPrices = async (card, _start, _end) => {
+    // @TODO: luxon
+    let yesterday = new Date(Date.now());
+    yesterday.setDate(yesterday.getDate() - 2);
+    let timeFilter = ``;
+    let limit = ``;
+    if (_start != null && _end != null) {
+        timeFilter = `AND dateTime(date) > dateTime($start) AND dateTime(date) < dateTime($end)`;
+    } else {
+        limit = "LIMIT 1";
+    }
+    let sql = `SELECT date(date) as date, cardId, variant, vendor, price FROM prices WHERE cardId = $cardId ${timeFilter} ORDER BY dateTime(date) DESC ${limit}`;
+    let db = pricesDB();
+    try {
+        let rows = db
+            .prepare(sql)
+            .all({ cardId: card.cardId, start: _start, end: _end });
+        db.close();
+        if (rows.length === 0 || rows[0].date < yesterday.getTime()) {
+            return await getTcgpPrice(card);
+        } else {
+            return rows;
         }
-    )
-}
+    } catch (err) {
+        db.close();
+        return Promise.reject(err);
+    }
+};
 
 /**
  * Returns the product prices for a given range or the latest price if no range is provided
- * @param {SealedProdcut} product 
- * @param {string} _start 
- * @param {string} _end 
- * @returns 
+ * @param {SealedProdcut} product
+ * @param {string} _start
+ * @param {string} _end
+ * @returns
  */
-const getProductPrice = (product, _start, _end) => {
-    return new Promise(
-        (resolve, reject) => {
-            let yesterday = new Date(Date.now())
-            yesterday.setDate(yesterday.getDate() - 2)
-            let timeFilter = ``
-            let limit = ``
-            if (_start != null && _end != null) {
-                timeFilter = `AND dateTime(date) > dateTime($start) AND dateTime(date) < dateTime($end)`
-            } else {
-                limit = "LIMIT 1"
-            }
-            let sql = `SELECT name, date(date) as date, vendor, price FROM productPrices WHERE name = $name ${timeFilter} ORDER BY datetime(date) DESC ${limit}`
-            let db = pricesDB()
-            try {
-                let rows = db.prepare(sql).all({ "name": product.name, "start": _start, "end": _end })
-                if (rows.length === 0 || rows[0].date < yesterday.getTime()) {
-                    getTcgpPriceProduct(product).then(
-                        (value) => {
-                            resolve(value)
-                        }
-                    ).catch(
-                        (err) => {
-                            reject(err)
-                        }
-                    )
-                } else {
-                    resolve(rows)
-                }
-            } catch (err) {
-                reject(err)
-            } finally {
-                db.close()
-            }
+const getProductPrice = async (product, _start, _end) => {
+    // @TODO: luxon
+    let yesterday = new Date(Date.now());
+    yesterday.setDate(yesterday.getDate() - 2);
+    let timeFilter = ``;
+    let limit = ``;
+    if (_start != null && _end != null) {
+        timeFilter = `AND dateTime(date) > dateTime($start) AND dateTime(date) < dateTime($end)`;
+    } else {
+        limit = "LIMIT 1";
+    }
+    let sql = `SELECT name, date(date) as date, vendor, price FROM productPrices WHERE name = $name ${timeFilter} ORDER BY datetime(date) DESC ${limit}`;
+    let db = pricesDB();
+    try {
+        let rows = db
+            .prepare(sql)
+            .all({ name: product.name, start: _start, end: _end });
+        db.close();
+        if (rows.length === 0 || rows[0].date < yesterday.getTime()) {
+            return await getTcgpPriceProduct(product);
+        } else {
+            return rows;
         }
-    )
-}
+    } catch (err) {
+        db.close();
+        Promise.reject(err);
+    }
+};
 
 /**
- * 
- * @param {string} collection 
+ *
+ * @param {string} collection
  * @returns {string} output
  */
 const getCollectionDownload = (collection, type) => {
-    let db = collectionDB()
-    let sqlAttach = `ATTACH DATABASE '${path.join(pwd(), CARD_DB_FILE)}' AS cardDB;`
-    let sql = `SELECT * FROM collectionCards colCards INNER JOIN cardDB.cards cards ON cards.cardId = colCards.cardId ` +
-        `WHERE colCards.collection = '${collection}'`
-    try {
-        db.prepare(sqlAttach).run()
-        let cards = db.prepare(sql).all()
-        switch (type) {
-            case "JSON":
-                return JSON.stringify(cards, null, 1)
-            case "CSV":
-                const fields = ['name', 'expName', 'expCardNumber', 'rarity', 'energyType', 'cardType', 'pokedex', 'variant', 'grade', 'paid', 'count'];
-                const opts = { fields };
-                return parse(cards, opts)
-            case "txt-TCGP":
-                let list = ""
-                for (let card of cards) {
-                    list += `${card.count} ${card.name} [${card.expCodeTCGP}]\n`
-                }
-                return list
-        }
-    } catch (err) {
-        console.log(err)
-        res.status(500).send(err)
-    } finally {
-        db.close()
+    let db = collectionDB();
+    let sqlAttach = `ATTACH DATABASE '${path.join(
+        pwd(),
+        CARD_DB_FILE
+    )}' AS cardDB;`;
+    let sql =
+        `SELECT * FROM collectionCards colCards INNER JOIN cardDB.cards cards ON cards.cardId = colCards.cardId ` +
+        `WHERE colCards.collection = '${collection}'`;
+    db.prepare(sqlAttach).run();
+    let cards = db.prepare(sql).all();
+    db.close();
+    switch (type) {
+        case "JSON":
+            return JSON.stringify(cards, null, 1);
+        case "CSV":
+            const opts = {
+                fields: [
+                    "name",
+                    "expName",
+                    "expCardNumber",
+                    "rarity",
+                    "energyType",
+                    "cardType",
+                    "pokedex",
+                    "variant",
+                    "grade",
+                    "paid",
+                    "count",
+                ],
+            };
+            return parse(cards, opts);
+        case "txt-TCGP":
+            return cards
+                .map(
+                    (card) => `${card.count} ${card.name} [${card.expCodeTCGP}]`
+                )
+                .join("\n");
+        default:
+            throw Error(`Unknown export type: ${type}`);
     }
-}
+};
 
 /**
- * Removes old time format.  can be removed @ v1
- * @param {*} prices 
+ * Removes old time format.
+ * @deprecated can be removed @ v1
+ * @param {*} prices
  */
-function upgradePrices(prices){
-    let oldprices = prices.prepare(`SELECT * FROM prices where dateTime(date) is null`).all()
-    for(let price of oldprices){
-        let date = new Date(price.date)
-        prices.prepare(`UPDATE prices SET date = $date`).run({date: date.toISOString()})
+function upgradePrices(prices) {
+    let oldprices = prices
+        .prepare(`SELECT * FROM prices where dateTime(date) is null`)
+        .all();
+    for (let price of oldprices) {
+        let date = new Date(price.date);
+        prices
+            .prepare(`UPDATE prices SET date = $date`)
+            .run({ date: date.toISOString() });
     }
 }
 
-const init = async () => {
+const init = () => {
     try {
-        let prices = pricesDB()
-        prices.prepare(`CREATE TABLE IF NOT EXISTS prices (id TEXT UNIQUE, date TEXT, cardId TEXT, variant TEXT, vendor TEXT, price REAL)`).run()
-        prices.prepare(`CREATE TABLE IF NOT EXISTS productPrices (id TEXT UNIQUE, date TEXT, name TEXT, vendor TEXT, price REAL)`).run()
-        //upgradePrices(prices)
-        prices.close()
-        let collections = collectionDB()
-        collections.prepare(`CREATE TABLE IF NOT EXISTS collections (name TEXT UNIQUE, img TEXT)`).run()
-        collections.prepare(`CREATE TABLE IF NOT EXISTS collectionCards (cardId TEXT, collection TEXT, variant TEXT, paid REAL, count INTEGER, grade TEXT)`).run()
-        collections.prepare(`CREATE TABLE IF NOT EXISTS collectionProducts (name TEXT, collection TEXT, paid REAL, count INTEGER)`).run()
-        collections.close()
+        let prices = pricesDB();
+        prices
+            .prepare(
+                `CREATE TABLE IF NOT EXISTS prices (id TEXT UNIQUE, date TEXT, cardId TEXT, variant TEXT, vendor TEXT, price REAL)`
+            )
+            .run();
+        prices
+            .prepare(
+                `CREATE TABLE IF NOT EXISTS productPrices (id TEXT UNIQUE, date TEXT, name TEXT, vendor TEXT, price REAL)`
+            )
+            .run();
+        prices.close();
+        let collections = collectionDB();
+        collections
+            .prepare(
+                `CREATE TABLE IF NOT EXISTS collections (name TEXT UNIQUE, img TEXT)`
+            )
+            .run();
+        collections
+            .prepare(
+                `CREATE TABLE IF NOT EXISTS collectionCards (cardId TEXT, collection TEXT, variant TEXT, paid REAL, count INTEGER, grade TEXT)`
+            )
+            .run();
+        collections
+            .prepare(
+                `CREATE TABLE IF NOT EXISTS collectionProducts (name TEXT, collection TEXT, paid REAL, count INTEGER)`
+            )
+            .run();
+        collections.close();
     } catch (err) {
-        console.error(err)
+        console.error(err);
     }
-}
+};
 
-module.exports.appPath = appPath
-module.exports.getCollectionDownload = getCollectionDownload
-module.exports.dbStatus = dbStatus
-module.exports.init = init
-module.exports.pwd = pwd
-module.exports.pricesDB = pricesDB 
-module.exports.collectionDB = collectionDB
-module.exports.cardDB = cardDB
-module.exports.checkForDbUpdate = checkForDbUpdate
-module.exports.getProductPrice = getProductPrice
-module.exports.getPrices = getPrices
-module.exports.CARD_DB_FILE = CARD_DB_FILE
-module.exports.COLLECTION_DB_FILE = COLLECTION_DB_FILE
-module.exports.PRICE_DB_FILE = PRICE_DB_FILE
+module.exports.getCollectionDownload = getCollectionDownload;
+module.exports.dbStatus = dbStatus;
+module.exports.init = init;
+module.exports.pricesDB = pricesDB;
+module.exports.collectionDB = collectionDB;
+module.exports.cardDB = cardDB;
+module.exports.checkForDbUpdate = checkForDbUpdate;
+module.exports.getProductPrice = getProductPrice;
+module.exports.getPrices = getPrices;
+module.exports.CARD_DB_FILE = CARD_DB_FILE;
+module.exports.COLLECTION_DB_FILE = COLLECTION_DB_FILE;
+module.exports.PRICE_DB_FILE = PRICE_DB_FILE;

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -4,12 +4,13 @@ const path = require('path');
 const url = require('url');
 const mw = require("./middleware")
 const DB = require("./database")
+const { appPath, pwd } = require("./utils");
 
 let mainWindow;
 
 function createWindow () {
   const startUrl = process.env.ELECTRON_START_URL ||url.format({
-        pathname: path.join(DB.appPath(), './index.html'),
+        pathname: path.join(appPath(), './index.html'),
         protocol: 'file:',
         slashes: true,
       });
@@ -21,8 +22,8 @@ function createWindow () {
 }
 
 //Start
-if(fs.existsSync(path.join(DB.pwd(),"sql/")) === false){
-  fs.mkdirSync(path.join(DB.pwd(),'sql/'))
+if(fs.existsSync(path.join(pwd(),"sql/")) === false){
+  fs.mkdirSync(path.join(pwd(),'sql/'))
 }
 
 mw.start()

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -7,13 +7,14 @@ const app = express();
 const fileCacheMiddleware = require("express-asset-file-cache-middleware");
 const bodyParser = require('body-parser');
 const DB = require('./database');
+const { pwd } = require("./utils");
 const os = require('os');
 
 let server
 
 //Start web server
 const start = async () => {
-    await DB.checkForDbUpdate().catch((err) => console.log(err))
+    await DB.checkForDbUpdate().catch((err) => console.error(err));
     DB.init()
     server = app.listen(3030)
 }
@@ -54,7 +55,7 @@ app.get("/cardImg/:asset_id",
             db.close()
         }
     },
-    fileCacheMiddleware({ cacheDir: path.join(DB.pwd(), "./cardImg"), maxSize: 1024 * 1024 * 1024 }),
+    fileCacheMiddleware({ cacheDir: path.join(pwd(), "./cardImg"), maxSize: 1024 * 1024 * 1024 }),
     (_, res) => {
         res.set({
             "Content-Type": res.locals.contentType,
@@ -86,7 +87,7 @@ app.get("/sealedImg/:asset_name",
             db.close()
         }
     },
-    fileCacheMiddleware({ cacheDir: path.join(DB.pwd(), "./productImg"), maxSize: 1024 * 1024 * 1024 }),
+    fileCacheMiddleware({ cacheDir: path.join(pwd(), "./productImg"), maxSize: 1024 * 1024 * 1024 }),
     (_, res) => {
         res.set({
             "Content-Type": res.locals.contentType,
@@ -117,7 +118,7 @@ app.get("/seriesImg/:asset_id",
             db.close()
         }
     },
-    fileCacheMiddleware({ cacheDir: path.join(DB.pwd(), "./seriesImg"), maxSize: 1024 * 1024 * 1024 }),
+    fileCacheMiddleware({ cacheDir: path.join(pwd(), "./seriesImg"), maxSize: 1024 * 1024 * 1024 }),
     (_, res) => {
         res.set({
             "Content-Type": res.locals.contentType,
@@ -148,7 +149,7 @@ app.get("/expLogo/:asset_id",
             db.close()
         }
     },
-    fileCacheMiddleware({ cacheDir: path.join(DB.pwd(), "./expLogo"), maxSize: 1024 * 1024 * 1024 }),
+    fileCacheMiddleware({ cacheDir: path.join(pwd(), "./expLogo"), maxSize: 1024 * 1024 * 1024 }),
     (_, res) => {
         res.set({
             "Content-Type": res.locals.contentType,
@@ -179,7 +180,7 @@ app.get("/expSymbol/:asset_id",
             db.close()
         }
     },
-    fileCacheMiddleware({ cacheDir: path.join(DB.pwd(), "./expSymbol"), maxSize: 1024 * 1024 * 1024 }),
+    fileCacheMiddleware({ cacheDir: path.join(pwd(), "./expSymbol"), maxSize: 1024 * 1024 * 1024 }),
     (_, res) => {
         res.set({
             "Content-Type": res.locals.contentType,
@@ -407,7 +408,7 @@ app.get("/collections", (_, res) => {
     try {
         let collections = db.prepare(`SELECT * FROM collections`).all()
         res.send(collections)
-    } catch {
+    } catch (err) {
         console.log(err)
         res.status(500).send(err)
     } finally {
@@ -550,8 +551,8 @@ app.get("/collections/:collection/cards/:page", (req, res) => {
     ${order}`
     let limit = `LIMIT 25 OFFSET ${(req.params.page) * 25}`
 
-    let sqlAttachCard = `ATTACH DATABASE '${path.join(DB.pwd(), DB.CARD_DB_FILE)}' AS cardDB;`
-    let sqlAttachColl = `ATTACH DATABASE '${path.join(DB.pwd(), DB.COLLECTION_DB_FILE)}' AS collectionDB;`
+    let sqlAttachCard = `ATTACH DATABASE '${path.join(pwd(), DB.CARD_DB_FILE)}' AS cardDB;`
+    let sqlAttachColl = `ATTACH DATABASE '${path.join(pwd(), DB.COLLECTION_DB_FILE)}' AS collectionDB;`
 
     try {
         db.prepare(sqlAttachCard).run()
@@ -648,7 +649,7 @@ app.get("/collections/:collection/sealed/:page", (req, res) => {
         ${NAME_FILTER}
         ${order}`
     let limit = `LIMIT 25 OFFSET ${(req.params.page) * 25}`
-    let sqlAttachCard = `ATTACH DATABASE '${path.join(DB.pwd(), DB.CARD_DB_FILE)}' AS cardDB;`
+    let sqlAttachCard = `ATTACH DATABASE '${path.join(pwd(), DB.CARD_DB_FILE)}' AS cardDB;`
 
     try {
         db.prepare(sqlAttachCard).run()
@@ -680,8 +681,8 @@ app.get("/collections/:collection/value", (req, res) => {
     WHERE _collections.collection = $collection
     GROUP BY _price.cardId, _price.variant`
 
-    let sqlAttachCard = `ATTACH DATABASE '${path.join(DB.pwd(), DB.CARD_DB_FILE)}' AS cardDB;`
-    let sqlAttachColl = `ATTACH DATABASE '${path.join(DB.pwd(), DB.COLLECTION_DB_FILE)}' AS collectionDB;`
+    let sqlAttachCard = `ATTACH DATABASE '${path.join(pwd(), DB.CARD_DB_FILE)}' AS cardDB;`
+    let sqlAttachColl = `ATTACH DATABASE '${path.join(pwd(), DB.COLLECTION_DB_FILE)}' AS collectionDB;`
     let db = DB.pricesDB()
     try {
         db.prepare(sqlAttachCard).run()

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -1,0 +1,46 @@
+const path = require("path");
+const os = require("os");
+
+const { app } = require("electron");
+
+/**
+ * Get the working directory for the application.
+ * @returns Working directory string.
+ */
+function pwd() {
+    if (process.env.NODE_ENV === "development") {
+        return "./dev-data";
+    } else if (process.env.NODE_ENV === "ci-test") {
+        return path.join(process.env.PWD, "/build");
+    } else if (process.env.NODE_ENV === "test") {
+        return "./test/data";
+    }
+    return app.getPath("appData");
+}
+
+/**
+ * Get the path to the application based on ENV or platform.
+ * @returns application path.
+ */
+const appPath = () => {
+    if (process.env.NODE_ENV === "development") {
+        return "./";
+    } else if (process.env.NODE_ENV === "ci-test") {
+        return path.join(process.env.PWD, "/build");
+    } else if (process.env.NODE_ENV === "test") {
+        return "./test/data";
+    }
+    switch (os.platform()) {
+        case "darwin":
+            return "/Applications/PokeTrax.app/Contents/";
+        case "win32":
+            return "";
+        default:
+            return process.env.PWD;
+    }
+};
+
+module.exports = {
+    appPath,
+    pwd,
+};

--- a/test/rest-tests.js
+++ b/test/rest-tests.js
@@ -1,241 +1,281 @@
-const mw = require('../src/server/middleware')
-const axios = require('axios')
-const fs = require('fs')
-const path = require('path')
-const assert = require('assert');
-const DB = require('../src/server/database')
+const mw = require("../src/server/middleware");
+const fs = require("fs");
+const fetch = require("node-fetch");
+const assert = require("assert");
+const { pwd } = require("../src/server/utils");
 
-before(
-    async () => {
-        await mw.start()
-    }
-)
+before(() => mw.start());
 
-describe(
-    'Test Image retreival',
-    () => {
-        it('Test pull card img', async () => {
-            await axios.get(`http://localhost:3030/cardImg/${encodeURIComponent(`SWSH09-Brilliant-Stars-Ultra-Ball-150`)}`).then(
-                (res) => {
-                    assert.ok(res.status === 200)
-                }
-            ).catch(
-                (err) => {
-                    // console.log(err.response)
-                    fail(err.response)
-                }
-            )
-        })
-        it('Test pull series img', async () => {
-            await axios.get(`http://localhost:3030/seriesImg/Sword%20&%20Shield`).then(
-                (res) => {
-                    assert.ok(res.status === 200)
-                }
-            ).catch(
-                (err) => {
-                    fail(err)
-                }
-            )
-        })
-        it('Test pull expLogo img', async () => {
-            await axios.get(`http://localhost:3030/expLogo/Brilliant%20Stars`).then(
-                (res) => {
-                    assert.ok(res.status === 200)
-                }
-            ).catch(
-                (err) => {
-                    fail(err)
-                }
-            )
-        })
-        it('Test pull expSymbol img', async () => {
-            await axios.get(`http://localhost:3030/expSymbol/Brilliant%20Stars`).then(
-                (res) => {
-                    assert.ok(res.status === 200)
-                }
-            ).catch(
-                (err) => {
-                    throw new Error(err)
-                }
-            )
-        })
-    }
-)
+describe("Test Image retreival", () => {
+    it("Test pull card img", async () => {
+        const res = await fetch(
+            `http://localhost:3030/cardImg/${encodeURIComponent(
+                `SWSH09-Brilliant-Stars-Ultra-Ball-150`
+            )}`
+        );
+        assert.equal(res.status, 200);
+    });
+    it("Test pull series img", async () => {
+        const res = await fetch(
+            `http://localhost:3030/seriesImg/Sword%20&%20Shield`
+        );
+        assert.equal(res.status, 200);
+    });
+    it("Test pull expLogo img", async () => {
+        const res = await fetch(
+            `http://localhost:3030/expLogo/Brilliant%20Stars`
+        );
+        assert.equal(res.status, 200);
+    });
+    it("Test pull expSymbol img", async () => {
+        const res = await fetch(
+            `http://localhost:3030/expSymbol/Brilliant%20Stars`
+        );
+        assert.equal(res.status, 200);
+    });
+});
 
-describe(
-    'Meta Rest Tests',
-    () => {
-        it('Test Pull series', async () => {
-            let series = await axios.get("http://localhost:3030/series")
-            assert.ok(series.data.find((value) => value.name === 'Sword & Shield'), "Cound not find series")
+describe("Meta Rest Tests", () => {
+    it("Test Pull series", async () => {
+        const series = await fetch("http://localhost:3030/series").then((res) =>
+            res.json()
+        );
+        assert.ok(
+            series.find((value) => value.name === "Sword & Shield"),
+            "Cound not find series"
+        );
+    });
+    it("Test Pull Expansions", async () => {
+        const exps = await fetch("http://localhost:3030/expansions").then(
+            (res) => res.json()
+        );
+        assert.ok(
+            exps.find((value) => value.name === "Brilliant Stars"),
+            "Could not find expansion"
+        );
+    });
+});
+
+describe("Card Rest Search Tests", () => {
+    it("Search all cards", async () => {
+        const cards = await fetch("http://localhost:3030/cards/0").then((res) =>
+            res.json()
+        );
+        assert.notEqual(cards.total, 0);
+    });
+    it("Search for 1 card", async () => {
+        const cards = await fetch(
+            `http://localhost:3030/cards/0?name=${encodeURIComponent(
+                "Brilliant Stars Ultra Ball 150"
+            )}`
+        ).then((res) => res.json());
+        assert.equal(
+            cards.total,
+            1,
+            `number of results not right ${JSON.stringify(cards)}`
+        );
+        assert.equal(
+            cards.cards[0].cardId,
+            "SWSH09-Brilliant-Stars-Ultra-Ball-150",
+            `Name is not right ${JSON.stringify(cards)}`
+        );
+    });
+});
+
+describe("Collection Rest Tests", () => {
+    it("Add Collection", async () => {
+        const c1 = fetch("http://localhost:3030/collections", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "collection1" }),
         });
-        it('Test Pull Expansions', async () => {
-            let exps = await axios.get("http://localhost:3030/expansions")
-            assert.ok(exps.data.find((value) => value.name === 'Brilliant Stars'), "Could not find expansion")
+        const c2 = fetch("http://localhost:3030/collections", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "collection2" }),
         });
-    }
-)
+        const res = await Promise.all([c1, c2]);
+        res.forEach((r) => assert.ok(r.status, 200));
+    });
+    it("Get Collections", async () => {
+        const res = await fetch("http://localhost:3030/collections").then(
+            (res) => res.json()
+        );
+        assert.ok(
+            res.find((value) => value.name === "collection1"),
+            `Did not find collection ${JSON.stringify(res)}`
+        );
+    });
 
-describe(
-    'Card Rest Search Tests',
-    () => {
-        it('Search all cards', async () => {
-            let cards = await axios.get("http://localhost:3030/cards/0")
-            assert.ok(cards.data.total != 0, `No results found ${cards.data}`)
+    it("Add Cards", async () => {
+        const cards = JSON.parse(fs.readFileSync("./test/testCollection.json"));
+        const reqs = cards.map((card) =>
+            fetch("http://localhost:3030/collections/card", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(card),
+            })
+        );
+        const res = await Promise.all(reqs);
+        res.forEach(({ status }) =>
+            assert.equal(status, 201, `Status not right ${status}`)
+        );
+    });
+
+    it("Test Get Cards", async () => {
+        const [col1, col2] = [
+            fetch("http://localhost:3030/collections/collection1/cards/0"),
+            fetch("http://localhost:3030/collections/collection2/cards/0"),
+        ].map((res) => res.then((r) => r.json()));
+        const [res1, res2] = await Promise.all([col1, col2]);
+        assert.equal(
+            res1.total,
+            3,
+            `Number of cards in Collection 1 not right ${JSON.stringify(
+                res1.total
+            )}`
+        );
+        assert.equal(
+            res2.total,
+            1,
+            `Number of cards in Collection 2 not right ${JSON.stringify(
+                res2.total
+            )}`
+        );
+    });
+
+    it("Update cards", async () => {
+        await fetch("http://localhost:3030/collections/card", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                cardId: "SWSH09-Brilliant-Stars-Choice-Belt-135",
+                collection: "collection2",
+                variant: "Normal",
+                paid: 1.0,
+                count: 2,
+                grade: "",
+                idTCGP: 263857,
+                name: "Choice Belt",
+                expIdTCGP: "SWSH09 Brilliant Stars",
+                expName: "Brilliant Stars",
+                expCardNumber: "135",
+                expCodeTCGP: "SWSH09",
+                rarity: "Uncommon",
+                img: "https://product-images.tcgplayer.com/fit-in/437x437/263857.jpg",
+                price: 0.17,
+                description:
+                    "The attacks of the Pokemon this card is attached to do 30 more damage to your opponent's Active Pokemon V <em>(before applying Weakness and Resistance)</em>.",
+                releaseDate: "2022-02-25T00:00:00Z",
+                energyType: "",
+                cardType: "Item",
+                pokedex: 100000,
+                variants: '["Normal","Reverse Holofoil"]',
+            }),
         });
-        it('Search for 1 card', async () => {
-            let cards = await axios.get(`http://localhost:3030/cards/0?name=${encodeURIComponent(`Brilliant Stars Ultra Ball 150`)}`)
-            assert.equal(cards.data.total, 1, `number of results not right ${JSON.stringify(cards.data)}`)
-            assert.equal(cards.data.cards[0].cardId, 'SWSH09-Brilliant-Stars-Ultra-Ball-150', `Name is not right ${JSON.stringify(cards.data)}`)
+        const res = await fetch(
+            "http://localhost:3030/collections/collection2/cards/0"
+        ).then((res) => res.json());
+        assert.equal(res.total, 1);
+        const { cards } = res;
+        assert.equal(
+            cards[0].variant,
+            "Normal",
+            `variant not set ${JSON.stringify(cards[0], null, 1)}`
+        );
+        assert.equal(
+            cards[0].paid,
+            1.0,
+            `Paid not set ${JSON.stringify(cards[0])}`
+        );
+        assert.equal(cards[0].count, 2, `Count not set ${cards[0]}`);
+        await fetch("http://localhost:3030/collections/card", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                cardId: "SWSH09-Brilliant-Stars-Choice-Belt-135",
+                collection: "collection2",
+                variant: "Reverse Holofoil",
+                paid: 1.0,
+                count: 1,
+                grade: "",
+                idTCGP: 263857,
+                name: "Choice Belt",
+                expIdTCGP: "SWSH09 Brilliant Stars",
+                expName: "Brilliant Stars",
+                expCardNumber: "135",
+                expCodeTCGP: "SWSH09",
+                rarity: "Uncommon",
+                img: "https://product-images.tcgplayer.com/fit-in/437x437/263857.jpg",
+                price: 0.17,
+                description:
+                    "The attacks of the Pokemon this card is attached to do 30 more damage to your opponent's Active Pokemon V <em>(before applying Weakness and Resistance)</em>.",
+                releaseDate: "2022-02-25T00:00:00Z",
+                energyType: "",
+                cardType: "Item",
+                pokedex: 100000,
+                variants: '["Normal","Reverse Holofoil"]',
+            }),
         });
-    }
-)
+        const res2 = await fetch(
+            "http://localhost:3030/collections/collection2/cards/0"
+        ).then((res) => res.json());
+        assert.equal(res2.total, 2);
+    });
 
-describe(
-    'Collection Rest Tests',
-    () => {
-        it('Add Collection', async () => {
-            let res = await axios.put("http://localhost:3030/collections", { 'name': 'collection1' })
-            await axios.put("http://localhost:3030/collections", { 'name': 'collection2' })
-            assert.ok(res.status === 201)
-        })
-        it('Get Collections', async () => {
-            return axios.get("http://localhost:3030/collections").then(
-                (res) => {
-                    assert.ok(res.data.find((value) => value.name === 'collection1'), `Did not find collection ${res.data}`)
-                }
-            ).catch(
-                (err) => {
-                    console.log(err)
-                }
-            )
-        })
-        
-        it('Add Cards', async () => {
-            let cards = JSON.parse(fs.readFileSync('./test/testCollection.json'))
-            for (let card of cards) {
-                try {
-                    let res = await axios.put("http://localhost:3030/collections/card", card)
-                    assert.equal(res.status, 201, `Status not right ${res.status}`)
-                } catch (err) {
-                    return new Error(err)
-                }
-            }
-        })
+    it("Delete card", async () => {
+        await fetch("http://localhost:3030/collections/card", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                cardId: "SWSH09-Brilliant-Stars-Choice-Belt-135",
+                collection: "collection2",
+                variant: "Normal",
+                paid: 1.0,
+                count: 2,
+                grade: "",
+                idTCGP: 263857,
+                name: "Choice Belt",
+                expIdTCGP: "SWSH09 Brilliant Stars",
+                expName: "Brilliant Stars",
+                expCardNumber: "135",
+                expCodeTCGP: "SWSH09",
+                rarity: "Uncommon",
+                img: "https://product-images.tcgplayer.com/fit-in/437x437/263857.jpg",
+                price: 0.17,
+                description:
+                    "The attacks of the Pokemon this card is attached to do 30 more damage to your opponent's Active Pokemon V <em>(before applying Weakness and Resistance)</em>.",
+                releaseDate: "2022-02-25T00:00:00Z",
+                energyType: "",
+                cardType: "Item",
+                pokedex: 100000,
+                variants: '["Normal","Reverse Holofoil"]',
+            }),
+        });
+        const res = await fetch(
+            "http://localhost:3030/collections/collection2/cards/0"
+        ).then((r) => r.json());
+        assert.equal(res.total, 1);
+    });
 
-        it('Test Get Cards', async () => {
-            let resCol1 = await axios.get("http://localhost:3030/collections/collection1/cards/0")
-            let resCol2 = await axios.get("http://localhost:3030/collections/collection2/cards/0")
-            assert.equal(resCol1.data.total, 3, `Number of cards in Collection 1 not right ${JSON.stringify(resCol1.data)}`)
-            assert.equal(resCol2.data.total, 1, `Number of cards in Collection 2 not right ${JSON.stringify(resCol2.data)}`)
-        })
+    it("Delete collection", async () => {
+        await fetch("http://localhost:3030/collections", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "collection2" }),
+        });
+        let colls = await fetch("http://localhost:3030/collections/").then(
+            (r) => r.json()
+        );
+        let res = await fetch(
+            "http://localhost:3030/collections/collection2/cards/0"
+        ).then((r) => r.json());
+        assert.equal(colls.length, 1, "collection not deleted");
+        assert.equal(res.total, 0, "cards not deleted");
+    });
+});
 
-        it('Update cards', async () => {
-            await axios.put("http://localhost:3030/collections/card",
-                {
-                    "cardId": "SWSH09-Brilliant-Stars-Choice-Belt-135",
-                    "collection": "collection2",
-                    "variant": "Normal",
-                    "paid": 1.0,
-                    "count": 2,
-                    "grade": "",
-                    "idTCGP": 263857,
-                    "name": "Choice Belt",
-                    "expIdTCGP": "SWSH09 Brilliant Stars",
-                    "expName": "Brilliant Stars",
-                    "expCardNumber": "135",
-                    "expCodeTCGP": "SWSH09",
-                    "rarity": "Uncommon",
-                    "img": "https://product-images.tcgplayer.com/fit-in/437x437/263857.jpg",
-                    "price": 0.17,
-                    "description": "The attacks of the Pokemon this card is attached to do 30 more damage to your opponent's Active Pokemon V <em>(before applying Weakness and Resistance)</em>.",
-                    "releaseDate": "2022-02-25T00:00:00Z",
-                    "energyType": "",
-                    "cardType": "Item",
-                    "pokedex": 100000,
-                    "variants": "[\"Normal\",\"Reverse Holofoil\"]"
-                })
-            let res = await axios.get("http://localhost:3030/collections/collection2/cards/0")
-            assert.equal(res.data.total, 1)
-            let cards = res.data.cards
-            assert.equal(cards[0].variant, "Normal", `variant not set ${JSON.stringify(cards[0], null, 1)}`)
-            assert.equal(cards[0].paid, 1.0, `Paid not set ${JSON.stringify(cards[0])}`)
-            assert.equal(cards[0].count, 2, `Count not set ${cards[0]}`)
-            await axios.put("http://localhost:3030/collections/card",
-                {
-                    "cardId": "SWSH09-Brilliant-Stars-Choice-Belt-135",
-                    "collection": "collection2",
-                    "variant": "Reverse Holofoil",
-                    "paid": 1.0,
-                    "count": 1,
-                    "grade": "",
-                    "idTCGP": 263857,
-                    "name": "Choice Belt",
-                    "expIdTCGP": "SWSH09 Brilliant Stars",
-                    "expName": "Brilliant Stars",
-                    "expCardNumber": "135",
-                    "expCodeTCGP": "SWSH09",
-                    "rarity": "Uncommon",
-                    "img": "https://product-images.tcgplayer.com/fit-in/437x437/263857.jpg",
-                    "price": 0.17,
-                    "description": "The attacks of the Pokemon this card is attached to do 30 more damage to your opponent's Active Pokemon V <em>(before applying Weakness and Resistance)</em>.",
-                    "releaseDate": "2022-02-25T00:00:00Z",
-                    "energyType": "",
-                    "cardType": "Item",
-                    "pokedex": 100000,
-                    "variants": "[\"Normal\",\"Reverse Holofoil\"]"
-                })
-            let res2 = await axios.get("http://localhost:3030/collections/collection2/cards/0")
-            assert.equal(res2.data.total, 2)
-        })
-
-        it('Delete card', async () => {
-            await axios.delete("http://localhost:3030/collections/card",
-                {
-                    "data":
-                    {
-                        "cardId": "SWSH09-Brilliant-Stars-Choice-Belt-135",
-                        "collection": "collection2",
-                        "variant": "Normal",
-                        "paid": 1.0,
-                        "count": 2,
-                        "grade": "",
-                        "idTCGP": 263857,
-                        "name": "Choice Belt",
-                        "expIdTCGP": "SWSH09 Brilliant Stars",
-                        "expName": "Brilliant Stars",
-                        "expCardNumber": "135",
-                        "expCodeTCGP": "SWSH09",
-                        "rarity": "Uncommon",
-                        "img": "https://product-images.tcgplayer.com/fit-in/437x437/263857.jpg",
-                        "price": 0.17,
-                        "description": "The attacks of the Pokemon this card is attached to do 30 more damage to your opponent's Active Pokemon V <em>(before applying Weakness and Resistance)</em>.",
-                        "releaseDate": "2022-02-25T00:00:00Z",
-                        "energyType": "",
-                        "cardType": "Item",
-                        "pokedex": 100000,
-                        "variants": "[\"Normal\",\"Reverse Holofoil\"]"
-                    }
-                })
-            let res = await axios.get("http://localhost:3030/collections/collection2/cards/0")
-            assert.equal(res.data.total, 1)
-        })
-
-        it("Delete collection", async () => {
-            await axios.delete("http://localhost:3030/collections",
-                { 'data': { 'name': 'collection2' } }
-            )
-            let colls = await axios.get("http://localhost:3030/collections/")
-            let res = await axios.get("http://localhost:3030/collections/collection2/cards/0")
-            assert.equal(colls.data.length, 1, "collection not deleted")
-            assert.equal(res.data.total, 0, "cards not deleted")
-        })
-    }
-)
-
-after(
-    () => {
-        mw.stop()
-        fs.rmSync(DB.pwd(), { recursive: true, force: true })
-    }
-)
+after(() => {
+    mw.stop();
+    fs.rmSync(pwd(), { recursive: true, force: true });
+});


### PR DESCRIPTION
This PR does the following things:

1. Pulls `pwd`, `appPath`, and the `fetch` dynamic import polyfill into a `utils.js`.
    - The dynamic import is needed because electron doesn't spoort es module syntax.
2. database.js has been cleaned up to return promises natively via async instead of wrapping everything in extra layers of promises.
3. Some streamlining has been done with respect to opening/closing dbs. TCG collection price checks/updates should now be much faster and more reliable when cold as I batched them into a Promise.all.
4. electron-rebuild has been added as a dev dependency to facilitate node upgrades and reruns of electron.
5. axios calls have been replaced with fetch across the board for the middleware.