### PR TITLE
fix: Paging shows top of next page.

### DIFF
--- a/src/pages/Collections.tsx
+++ b/src/pages/Collections.tsx
@@ -309,6 +309,9 @@ function DeleteDialog(props: DialogProps) {
 }
 
 export class Collections extends React.Component<{}, State> {
+
+    private scrollableBody: HTMLElement;
+
     constructor(props: {}) {
         super(props)
         this.state = new State()
@@ -368,7 +371,7 @@ export class Collections extends React.Component<{}, State> {
                 )
             let _display = display ?? this.state.display
             if (_display === "cards") {
-                getCollectionCards(collection, page, searchValue ?? this.state.searchValue, rarityFilter ?? this.state.rareSelected, sort ?? this.state.sort)
+                return getCollectionCards(collection, page, searchValue ?? this.state.searchValue, rarityFilter ?? this.state.rareSelected, sort ?? this.state.sort)
                     .then(
                         (search) => {
                             this.setState(
@@ -386,7 +389,7 @@ export class Collections extends React.Component<{}, State> {
                         }
                     )
             } else {
-                getCollectionSealed(collection, page, searchValue ?? this.state.searchValue, sort ?? this.state.sort)
+                return getCollectionSealed(collection, page, searchValue ?? this.state.searchValue, sort ?? this.state.sort)
                     .then(
                         (search) => {
                             this.setState(
@@ -423,8 +426,9 @@ export class Collections extends React.Component<{}, State> {
         this._getCollections()
     }
 
-    private handleChangePage = (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
-        this.setCollection(this.state.collection, newPage)
+    private handleChangePage = async (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+        await this.setCollection(this.state.collection, newPage);
+        this.scrollableBody.scrollTop = 0;
     };
 
     private renderCards() {
@@ -707,7 +711,7 @@ export class Collections extends React.Component<{}, State> {
                 </div>
                 <div>
                     {this.searchbar()}
-                    <div className='h-[calc(100vh-13rem)] overflow-auto'>
+                    <div className='h-[calc(100vh-13rem)] overflow-auto' ref={(e) => (this.scrollableBody = e)}>
                         {this.cardContainer()}
                     </div>
                 </div>

--- a/src/pages/ProductSearch.tsx
+++ b/src/pages/ProductSearch.tsx
@@ -16,20 +16,25 @@ class State {
 }
 
 export class ProductSearch extends React.Component<{}, State>{
-    constructor() {
-        super({})
+
+    private scrollableBody: HTMLElement;
+
+    constructor(props: {}) {
+        super(props);
         this.state = new State()
-        this.searchSealed(0)
     }
 
+    componentDidMount() {
+        this.searchSealed(0);
+    }
+
+
     private searchSealed(page: number, searchTerm?: string, sort?: string) {
-        searchProducts(page, searchTerm ?? this.state.searchTerm, sort ?? this.state.sort)
+        return searchProducts(page, searchTerm ?? this.state.searchTerm, sort ?? this.state.sort)
             .then(
                 (results: ProductList) => {
-                    console.log(results)
                     this.setState(
                         {
-                            ...this.state,
                             page: page,
                             searchTerm: searchTerm ?? this.state.searchTerm,
                             sort: sort ?? this.state.sort,
@@ -85,16 +90,19 @@ export class ProductSearch extends React.Component<{}, State>{
     }
 
     private renderProducts() {
-        let items = []
-        for (let i = 0; i < this.state.products.length; i++) {
-            let prod = this.state.products[i]
-            items.push(<ProductCase id={`${i}`} product={prod} onDelete={() => {}}></ProductCase>)
-        }
-        return items
+        return this.state.products.map((product, i) => (
+            <ProductCase
+                id={`${i}`}
+                key={i}
+                product={product}
+                onDelete={() => {}}
+            ></ProductCase>
+        ));
     }
 
-    private handleChangePage = (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number,) => {
-        this.searchSealed(newPage)
+    private handleChangePage = async (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number,) => {
+        await this.searchSealed(newPage);
+        this.scrollableBody.scrollTop = 0;
     };
 
     private pagination() {
@@ -114,7 +122,7 @@ export class ProductSearch extends React.Component<{}, State>{
         return (
             <div>
                 {this.searchbar()}
-                <div className='h-[calc(100vh-12rem)] overflow-auto'>
+                <div className='h-[calc(100vh-12rem)] overflow-auto' ref={(e) => (this.scrollableBody = e)}>
                     {this.pagination()}
                     <div className='flex'>
                         <div className='flex-grow'></div>


### PR DESCRIPTION
## Primary Fix
This PR fixes an issue where hitting next/previous page for:

- CardSearch
- ProductSearch
- Collections

Would leave the user at the bottom of the subsequent page. With this fix, pagination now pops you to the top of the page.

## Other Fixes

- Tidied up some code in those components.
- Used Promise.all when possible to reliably load unrelated promises.
- this.setX (which was being called on page) now properly returns a promise. This allows us to await the set call and only scroll to the top when the next page of data has been loaded.
- Still finding/cleaning up more spots where iteration is used to create a bunch of the same components but the key property is not set.